### PR TITLE
Update README.md => correcting Typo, Installation advice

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,30 @@ Simple bundle to add 2 new types to Doctrine
 
 It relies on libSodium for encryption
 
+## Installation
+The Installation is quite simple: 
+
+1. Require the Bundle via composer:
+```text
+composer require gracious/doctrine-encryption-bundle
+```
+2. Add the following to your doctrine.yaml:
+```yaml
+types:
+  encrypted: 'Gracious\DoctrineEncryptionBundle\Type\Encrypted'
+  encryptedArrayCollection: 'Gracious\DoctrineEncryptionBundle\Type\EncryptedArrayCollection'
+  hashed: 'Gracious\DoctrineEncryptionBundle\Type\Hashed'
+```
+3. Generate a 64 character encryption key, you could to this the following way:
+```php
+sodium_bin2hex(random_bytes(SODIUM_CRYPTO_SECRETBOX_KEYBYTES));
+```
+4. Add the following two settings to your .env file:
+```text
+ENABLE_ENCRYPTION=true
+ENCRYPTION_KEY=[PASTE ENCRYPTION KEY HERE]
+```
+
 ## Settings
 There are 2 settings at the moment, both are env vars
 
@@ -34,7 +58,7 @@ The following has to be added to you doctrine.yaml
 ```yaml
 types:
   encrypted: 'Gracious\DoctrineEncryptionBundle\Type\Encrypted'
-  encryptedArrayCollection: 'Gracious\DoctrineEncryptionBundle\Type\encryptedArrayCollection'
+  encryptedArrayCollection: 'Gracious\DoctrineEncryptionBundle\Type\EncryptedArrayCollection'
   hashed: 'Gracious\DoctrineEncryptionBundle\Type\Hashed'
 ```
 The block would look something like this:


### PR DESCRIPTION
It's a great Bundle with very useful functionality there is just one problem: The README has some weaknesses.

First and most importantly: the path to EncryptedArrayCollection Class had a Typo in it. Symfony will directly throw an exception when a user pastes this into his doctrine.yaml file and reloads the page.
Luckily I quickly found the mistake myself, otherwise most user's will probably remove the bundle almost instantaneously.

Second thing is that there is no installation guide.
This is bad for two reasons:
1. The bundle loses seriousness.
2. Some user's might not even try to install it.

I have added short Installation instructions and corrected the Typo and am now happily using this great bundle!
Thank :) 👍