### PR TITLE
Fixed the SQL comment to fix the issue with the detection of the column type

### DIFF
--- a/Type/Encrypted.php
+++ b/Type/Encrypted.php
@@ -20,7 +20,7 @@ class Encrypted extends Type
      */
     public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
     {
-        return 'TEXT COMMENT \'(Encrypted)\'';
+        return 'TEXT COMMENT \'(DC2Type:encrypted)\'';
     }
 
     /**

--- a/Type/EncryptedArrayCollection.php
+++ b/Type/EncryptedArrayCollection.php
@@ -21,7 +21,7 @@ class EncryptedArrayCollection extends Type
      */
     public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
     {
-        return 'LONGTEXT COMMENT \'(EncryptedArrayCollection)\'';
+        return 'LONGTEXT COMMENT \'(DC2Type:encryptedArrayCollection)\'';
     }
 
     /**

--- a/Type/Hashed.php
+++ b/Type/Hashed.php
@@ -20,7 +20,7 @@ class Hashed extends Type
      */
     public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
     {
-        return 'VARCHAR(255) COMMENT \'(Hashed)\'';
+        return 'VARCHAR(255) COMMENT \'(DC2Type:hashed)\'';
     }
 
     /**


### PR DESCRIPTION
The hashed and encrypted columns will not work correctly with the Doctrine Migrations Bundle. If you have columns with one of these types, the Migrations Bundle will always detect a change in the column and you can generate an unlimited number of new versions.

The problem is, that Doctrine can't detect these custom types in the existing table schema and then detects the column as 'String' columns with an additional 'comment' value. So with every version, Doctrine tries to solve this difference by setting the same values again and again.

With the fix i've made Doctrine can detect the custom column types correctly and does not identify it as an changed table.