### PR TITLE
Added compatibility with other DBMS and DBAL 4.0

### DIFF
--- a/Type/Encrypted.php
+++ b/Type/Encrypted.php
@@ -38,7 +38,7 @@ class Encrypted extends Type
      * @param AbstractPlatform $platform
      * @return string
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform) : string
+    public function convertToPHPValue($value, AbstractPlatform $platform): string
     {
         if (empty($value)) {
             return '';
@@ -58,7 +58,7 @@ class Encrypted extends Type
      * @return mixed
      * @throws \Exception
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): mixed
     {
         if (!isset($_ENV['ENABLE_ENCRYPTION']) || $_ENV['ENABLE_ENCRYPTION'] === 'false') {
             return $value;
@@ -73,13 +73,5 @@ class Encrypted extends Type
 
         $encryptedValue = sodium_crypto_secretbox($value, $nonce, $key);
         return sodium_bin2hex($nonce).'|'.sodium_bin2hex($encryptedValue);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function requiresSQLCommentHint(AbstractPlatform $platform)
-    {
-        return true;
     }
 }

--- a/Type/Encrypted.php
+++ b/Type/Encrypted.php
@@ -20,7 +20,7 @@ class Encrypted extends Type
      */
     public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
     {
-        return 'TEXT COMMENT \'(DC2Type:encrypted)\'';
+        return $platform->getClobTypeDeclarationSQL($fieldDeclaration);
     }
 
     /**

--- a/Type/Encrypted.php
+++ b/Type/Encrypted.php
@@ -74,4 +74,12 @@ class Encrypted extends Type
         $encryptedValue = sodium_crypto_secretbox($value, $nonce, $key);
         return sodium_bin2hex($nonce).'|'.sodium_bin2hex($encryptedValue);
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
 }

--- a/Type/EncryptedArrayCollection.php
+++ b/Type/EncryptedArrayCollection.php
@@ -93,4 +93,12 @@ class EncryptedArrayCollection extends Type
 
         return json_encode($encryptedArray);
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
 }

--- a/Type/EncryptedArrayCollection.php
+++ b/Type/EncryptedArrayCollection.php
@@ -21,7 +21,7 @@ class EncryptedArrayCollection extends Type
      */
     public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
     {
-        return 'LONGTEXT COMMENT \'(DC2Type:encryptedArrayCollection)\'';
+        return $platform->getClobTypeDeclarationSQL($fieldDeclaration);
     }
 
     /**

--- a/Type/EncryptedArrayCollection.php
+++ b/Type/EncryptedArrayCollection.php
@@ -69,7 +69,7 @@ class EncryptedArrayCollection extends Type
      * @return mixed
      * @throws \Exception
      */
-    public function convertToDatabaseValue($array, AbstractPlatform $platform)
+    public function convertToDatabaseValue($array, AbstractPlatform $platform): mixed
     {
         if (!isset($_ENV['ENABLE_ENCRYPTION']) || $_ENV['ENABLE_ENCRYPTION'] === 'false') {
             return $array;
@@ -92,13 +92,5 @@ class EncryptedArrayCollection extends Type
         }
 
         return json_encode($encryptedArray);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function requiresSQLCommentHint(AbstractPlatform $platform)
-    {
-        return true;
     }
 }

--- a/Type/Hashed.php
+++ b/Type/Hashed.php
@@ -20,7 +20,7 @@ class Hashed extends Type
      */
     public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
     {
-        return 'VARCHAR(255) COMMENT \'(DC2Type:hashed)\'';
+        return $platform->getVarcharTypeDeclarationSQL($fieldDeclaration);
     }
 
     /**

--- a/Type/Hashed.php
+++ b/Type/Hashed.php
@@ -42,4 +42,12 @@ class Hashed extends Type
     {
         return hash('whirlpool', $value);
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
 }

--- a/Type/Hashed.php
+++ b/Type/Hashed.php
@@ -20,7 +20,8 @@ class Hashed extends Type
      */
     public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
     {
-        return $platform->getVarcharTypeDeclarationSQL($fieldDeclaration);
+        $fieldDeclaration['length'] = 128;
+        return $platform->getStringTypeDeclarationSQL($fieldDeclaration);
     }
 
     /**
@@ -38,16 +39,8 @@ class Hashed extends Type
      * @param AbstractPlatform $platform
      * @return string
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform) : string
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): string
     {
         return hash('whirlpool', $value);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function requiresSQLCommentHint(AbstractPlatform $platform)
-    {
-        return true;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -6,10 +6,13 @@
     "require": {
         "php": "^7.2|^8.0|^8.1|^8.2",
         "ext-sodium": "*",
+        "ext-json": "*",
+        "doctrine/dbal": "^4",
+        "doctrine/orm": "^3",
+        "doctrine/doctrine-bundle": "*",
+        "doctrine/doctrine-migrations-bundle": "*",
         "symfony/framework-bundle": "^4.0|^5.0|^6.0",
-        "symfony/flex": "^1.0|^2.0",
-        "symfony/orm-pack": "^2.0",
-        "ext-json": "*"
+        "symfony/flex": "^1.0|^2.0"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
### Intro

The Doctrine Encryption Bundle has hardcoded column data types. If you want to use the bundle with a different DBMS as MySQL, you cannot use it because other systems may have a different way of defining the comments, which sets the Doctrine type hint ("DC2Type"). For example, in PostgreSQL, you must specify the comments in a separate statement and not inline when defining the column.

### Changes

I replaced the hardcoded data types with the correct functions from DBAL.

For the comment, they offered a method `requireSQLCommentHint`, which has to return `true`, so DBAL automatically added the comment correctly for the DBMS. But this method is deprecated and was removed in DBAL 4.0.

Since I had other problems with my project, I switched it to DBAL 4.0 and ORM 3.0 and tested the bundle with these versions. Everything works fine, and the `requireSQLCommentHint` is not required (it has been removed, so it cannot be required anymore).

But because of this pull request in the `orm-pack` https://github.com/symfony/orm-pack/pull/43, the orm-pack is limited to DBAL 3, so if you want to use the Doctrine Encryption Bundle, it requires DBAL 3, but DBAL 3 requires the deprecated `requireSQLCommentHint` to work correctly. Because of this, I replaced the orm-pack in the `composer.json` with the `require` from the orm-pack.